### PR TITLE
コメント行をインデント対象に含めるオプションを追加した。

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,17 @@
 		"prettier": "^2.0.5",
 		"typescript": "^3.9.5",
 		"vscode": "^1.1.37"
+	},
+	"contributes": {
+		"configuration":{
+			"title": "eraindent",
+			"properties": {
+				"eraindent.indentCommentRow":{
+					"default":false,
+					"type":"boolean",
+					"description": "Enable to indent at comment row. The context of comments is ignored and follows the indentation in the code."
+				}
+			}
+		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,8 @@ export class EraIndentProvider
     options: vscode.FormattingOptions,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.TextEdit[]> {
-    const indenter = new indentor.EraIndenter(options);
+    const config = vscode.workspace.getConfiguration("eraindent");
+    const indenter = new indentor.EraIndenter(options, config);
     return this.innnerFormat(
       document,
       document.lineAt(document.lineCount - 1).range.end.line,
@@ -35,7 +36,8 @@ export class EraIndentProvider
     options: vscode.FormattingOptions,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.TextEdit[]> {
-    const indenter = new indentor.EraIndenter(options);
+    const config = vscode.workspace.getConfiguration("eraindent");
+    const indenter = new indentor.EraIndenter(options, config);
     const endline = range.end.line;
     return this.innnerFormat(document, endline, indenter);
   }
@@ -46,7 +48,8 @@ export class EraIndentProvider
     options: vscode.FormattingOptions,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.TextEdit[]> {
-    const indenter = new indentor.EraIndenter(options);
+    const config = vscode.workspace.getConfiguration("eraindent");
+    const indenter = new indentor.EraIndenter(options, config);
     const result = this.innnerFormat(document, position.line + 1, indenter);
     if (ch === "\n") {
       const newLine = indenter.newLine;


### PR DESCRIPTION
settings.jsonに`"eraindent.indentCommentRow": true`と記載するとコメント行の自動インデントが有効になります。
デフォルトは無効です。
```settings.json
{
    "files.autoGuessEncoding": true,
    "eraindent.indentCommentRow": true //←こんなかんじ
}
```
コメントの文脈は考慮されず、コード内のインデントに従います。
```erabasic
;xxxの場合
IF COND("xxx")
	PRINTFORML xxx
	;yyyの場合    ←こういうの
ELSEIF COND("yyy")
	PRINTFORML yyy
	;その他    ←こういうの
ELSE
	PRINTFORML zzz
ENDIF
```
```erabasic
IF COND("xxx")
	PRINTFORML xxx
	;DEBUGPRINT hoge ←こういうの
ELSEIF COND("yyy")
	PRINTFORML yyy
        ;○/○ 更新        ←こういうの　　　
        ;PRINTFORML aaa  ←こういうの
ELSE
	PRINTFORML zzz
ENDIF
```

他人のリポジトリにプルリクを出すのも、vscode拡張のソースをいじるのも初めてで勝手がわかっていないので、変なところありましたらご指摘お願いします。