### PR TITLE
ユーザー定義関数の内部をインデント対象にするオプションを追加した。

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,12 @@
         "eraindent.indentCommentRow": {
           "default": false,
           "type": "boolean",
-          "description": "Enable to indent at comment row. The context of comments is ignored and follows the indentation in the code."
+          "description": "%configuration.indentCommentRow.description%"
+        },
+        "eraindent.indentInsideOfFunction": {
+          "default": false,
+          "type": "boolean",
+          "description": "%configuration.indentInsideOfFunction.description%"
         }
       }
     }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,0 +1,4 @@
+{
+    "configuration.indentCommentRow.description": "コメント行の自動インデントを有効にします。コメントの文脈は考慮されず、コード内のインデントに従います。",
+    "configuration.indentInsideOfFunction.description": "ユーザー定義関数内部の自動インデントを有効にします。"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,4 @@
+{
+    "configuration.indentCommentRow.description": "Enable to indent at comment row. The context of comments is ignored and follows the indentation in the code.",
+    "configuration.indentInsideOfFunction.description": "Enable to indent at comment row. The context of comments is ignored and follows the indentation in the code."
+}

--- a/src/indenter.ts
+++ b/src/indenter.ts
@@ -69,6 +69,7 @@ export interface IndentState {
   readonly parseState: ParseState;
   readonly options: EraIndentorOptions;
   readonly indentCommentRow: boolean;
+  readonly indentInsideOfFunction: boolean;
 }
 
 export const makeIndentState = (
@@ -82,6 +83,7 @@ export const makeIndentState = (
     parseState: p,
     options: o,
     indentCommentRow: c.get("indentCommentRow", false),
+    indentInsideOfFunction: c.get("indentInsideOfFunction", false),
   };
 };
 
@@ -99,6 +101,7 @@ export interface NormalIndentState {
   readonly parseState: ParseNormal;
   readonly options: EraIndentorOptions;
   readonly indentCommentRow: boolean;
+  readonly indentInsideOfFunction: boolean;
 }
 
 export function isNormalState(state: IndentState): state is NormalIndentState {
@@ -524,6 +527,9 @@ export function getNextStateNormal(
     case LineState.DownUp:
       return state;
     case LineState.Function:
+      if (state.indentInsideOfFunction) {
+        return updateIndentState(state, { indentDepth: 1 });
+      }
       return updateIndentState(state, { indentDepth: 0 });
     case LineState.Up:
       return updateIndentState(state, { indentDepth: state.indentDepth + 1 });


### PR DESCRIPTION
settings.jsonに`"eraindent.indentInsideOfFunction": true`と記載すると、ユーザー定義関数内部の自動インデントが有効になります。
デフォルトは無効です。
ついでに、vscodeの表示言語がja(日本語)だった場合の、設定画面説明文のローカライズ対応を追加しています。

以下、例示
```
@HOGE(HUGA)
#DIM HUGA
PRINTFORM %HUGA%

@PIYO
PRINTL POYO
```
↓
```
@HOGE(HUGA)
    #DIM HUGA
    PRINTFORM %HUGA%

@PIYO
    PRINTL POYO
```